### PR TITLE
Fix install instructions for Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Install code and start development environment:
 ```
 git clone https://github.com/wikimedia/svgtranslate
 cd svgtranslate
+cp .env.dist .env
 docker-compose up
 ```
 


### PR DESCRIPTION
So that the environment variables are available to docker-compose
when it's run. Before, we were relying on composer to create
the .env file.