### PR TITLE
Switch to PNG rendering for image display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 /.phpcs-cache
 /phpcs.xml
 ###< squizlabs/php_codesniffer ###
+
+# Generated test data files.
+/tests/data/Speech_bubbles.png
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
 
 before_install:
   - npm -g install npm # Upgrade npm so we can use the ci install command.
+  - sudo apt-get install -y librsvg2-bin
 
 install:
   - composer install
@@ -15,7 +16,9 @@ script:
   - node_modules/.bin/encore production
   - git status
   - git status | grep "nothing to commit, working tree clean"
+  # Run linting.
   - composer lint
+  # Run tests.
   - composer test
 
 after_success:

--- a/bin/dockerstart
+++ b/bin/dockerstart
@@ -7,6 +7,8 @@ if [ -z $TOOLFORGE_DOCKER_PORT ]; then
 fi
 
 # Install dependencies.
+apt-get update
+apt-get install librsvg2-bin
 composer install -d /var/www || exit 1;
 
 # Start the Lighttpd web server. 

--- a/composer.json
+++ b/composer.json
@@ -68,10 +68,15 @@
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "@generate-test-data"
         ],
         "post-update-cmd": [
-            "@auto-scripts"
+            "@auto-scripts",
+            "@generate-test-data"
+        ],
+        "generate-test-data": [
+            "LANG=de rsvg-convert ./tests/data/Speech_bubbles.svg > ./tests/data/Speech_bubbles.png"
         ],
         "lint": [
             "composer validate",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -34,3 +34,7 @@ services:
     App\Service\FileCache:
         arguments:
             $directory: '%kernel.project_dir%/var/cache/images'
+
+    App\Service\Renderer:
+        arguments:
+            $rsvgCommand: '/usr/bin/rsvg-convert'

--- a/src/Controller/TranslateController.php
+++ b/src/Controller/TranslateController.php
@@ -137,6 +137,7 @@ class TranslateController extends AbstractController
             'upload_button' => $uploadButton,
             'language_selectors' => $languageSelectorsLayout,
             'translations' => $translations,
+            'target_lang' => $targetLangDefault,
         ]);
     }
 

--- a/src/Service/FileCache.php
+++ b/src/Service/FileCache.php
@@ -107,4 +107,14 @@ class FileCache
     {
         return $this->directory.DIRECTORY_SEPARATOR.$fileName;
     }
+
+    /**
+     * Create a file with a unique .svg filename, with access permission set to 0600,
+     * and return its name.
+     * @return string
+     */
+    public function getTempSvgFile(): string
+    {
+        return tempnam($this->directory, 'temp_').'.svg';
+    }
 }

--- a/src/Service/Renderer.php
+++ b/src/Service/Renderer.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Service;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+/**
+ * SVG to PNG rendering service.
+ */
+class Renderer
+{
+
+    /** @var string */
+    protected $rsvgCommand;
+
+    /**
+     * @param string $rsvgCommand The command to execute to do the conversion.
+     */
+    public function __construct(string $rsvgCommand)
+    {
+        $this->rsvgCommand = $rsvgCommand;
+    }
+
+    /**
+     * @param string $file Full filesystem path to the SVG file to render.
+     * @param string $lang Code of the language in which to render the image.
+     * @throws ProcessFailedException If the PNG conversion failed.
+     * @return string The PNG image contents.
+     */
+    public function render(string $file, string $lang) : string
+    {
+        $process = new Process([$this->rsvgCommand, $file]);
+        // Set the LANG environment variable, which will be interpreted as the SVG systemLanguage.
+        $process->setEnv(['LANG' => $lang]);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+        return $process->getOutput();
+    }
+}

--- a/templates/translate.html.twig
+++ b/templates/translate.html.twig
@@ -29,7 +29,7 @@
                 {{ download_button|raw }}
             </div>
             <div class="image">
-                <img src="{{ path('api_file', {fileName: filename}) }}" alt="{{ msg('translation-image-alt') }}" />
+                <img src="{{ path('api_file', {filename: filename, lang: target_lang}) }}" alt="{{ msg('translation-image-alt') }}" />
             </div>
         </div>
     </form>

--- a/tests/Model/Svg/SvgFileTest.php
+++ b/tests/Model/Svg/SvgFileTest.php
@@ -21,6 +21,12 @@ class SvgFileTest extends TestCase
 {
     public const TEST_FILE = __DIR__.'/../../data/Speech_bubbles.svg';
 
+    /**
+     * This PNG file is generated as part of the Composer installation process,
+     * because rsvg is not deterministic.
+     */
+    public const TEST_FILE_RENDERED = __DIR__.'/../../data/Speech_bubbles.png';
+
     public const EXPECTED_TRANSLATIONS = [
         'tspan2987' =>
             [

--- a/tests/Service/RendererTest.php
+++ b/tests/Service/RendererTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Tests\Service;
+
+use App\Service\Renderer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class RendererTest extends TestCase
+{
+
+    public function testInvalidCommand() : void
+    {
+        $renderer = new Renderer('foo');
+        static::expectException(ProcessFailedException::class);
+        static::expectExceptionMessage('foo: not found');
+        $renderer->render('foo.svg', 'fr');
+    }
+}


### PR DESCRIPTION
This patch changes the API to return PNG images instead of SVG,
so that we can specify the language that is used for the rendering.
To do this, we pass the name of the cached SVG file to a call to
the external rsvg-convert command, which returns the PNG to stdout.
This is served in the usual way.

This change also breaks the API URLs by adding in a 'lang' URL
parameter. This is required because we may not be rendering to the
tool user's current interface language.

When a POST request is given with new translations, the resulting
changed SVG file has to be written to the filesystem so that
rsvg-convert can access it. This is done by creating a new unique
temp file in the same images' cache directory, so that the files
thus created can be cleaned up by the existing clearing
mechanism.

The Docker image we're using doesn't (until T151656 is resolved)
have rsvg-convert installed, so this patch also adds this to the
dockerstart script.

Bug: https://phabricator.wikimedia.org/T211637