### PR TITLE
Add check for strict camelCased function names

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -20,4 +20,11 @@
             </property>
         </properties>
     </rule>
+
+    <rule ref="Generic.NamingConventions.CamelCapsFunctionName">
+        <properties>
+            <property name="strict" value="true" />
+        </properties>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
In #42 I made a typo in a method name that wasn't caught. This will catch it.