### PR TITLE
Remove path from default rsvg command

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -37,4 +37,4 @@ services:
 
     App\Service\Renderer:
         arguments:
-            $rsvgCommand: '/usr/bin/rsvg-convert'
+            $rsvgCommand: 'rsvg-convert'


### PR DESCRIPTION
It's not required if the web server user has it in their path,
and because it varies from system to system it's easier to
make that happen.

Bug: T214742