### PR TITLE
Update link for SVG Translate docs

### DIFF
--- a/templates/search.html.twig
+++ b/templates/search.html.twig
@@ -8,7 +8,7 @@
     <p>{{ msg('info') }}</p>
     <p>
         {{ msg('beta') }}
-        <a href="https://meta.wikimedia.org/wiki/Special:MyLanguage/Community_Tech/SVG_translation">{{ msg('learn-more') }}</a>
+        <a href="https://commons.wikimedia.org/wiki/Special:MyLanguage/Commons:SVG_Translate_tool">{{ msg('learn-more') }}</a>
     </p>
 {% endblock %}
 


### PR DESCRIPTION
Point to the shiny new documentation page on Commons. 