### PR TITLE
Fix Piwik-loading check to only load for production

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -76,7 +76,7 @@
     <script type="text/javascript">
 
         {# Matomo usage tracking #}
-        {% if 'prod' == app.environment and 'localhost' != app.request.server.get('SERVER_NAME') %}
+        {% if 'tools.wmflabs.org' == app.request.HttpHost and '/svgtranslate/' == asset('') %}
         var _paq = _paq || [];
         _paq.push(['trackPageView']);
         _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
Rather than only checking for localhost, the Piwik stats-sending
JS is loaded only for tools.wmflabs.org/svgtranslate/ and never
for any other configuration.

Bug: T215478