### PR TITLE
Add message for non-found files

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -24,6 +24,7 @@
   "search-placeholder": "100 Years War France 1435.svg",
   "translate-button": "Translate",
   "no-translations": "This file does not have any labels available for translation. Please pick another image.",
+  "not-found": "The file you requested could not be found. Please pick another image.",
 
   "pick-another": "← pick another file",
   "view-on-commons": "View on Commons",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -24,6 +24,7 @@
   "search-placeholder": "An example filename visible in the search box. Doesn't have to exist on Commons.",
   "translate-button": "Search button text.",
   "no-translations": "Error message displayed for SVGs that have nothing to translate.",
+  "not-found": "Error message displayed if the requested file could not be found.",
 
   "pick-another": "Label for backlink from the translate page to the search page.",
   "view-on-commons": "Link to view the file on Commons. The whole phrase is linked.",

--- a/public/assets/i18n/app/en.json
+++ b/public/assets/i18n/app/en.json
@@ -24,6 +24,7 @@
   "search-placeholder": "100 Years War France 1435.svg",
   "translate-button": "Translate",
   "no-translations": "This file does not have any labels available for translation. Please pick another image.",
+  "not-found": "The file you requested could not be found. Please pick another image.",
 
   "pick-another": "← pick another file",
   "view-on-commons": "View on Commons",

--- a/public/assets/i18n/app/qqq.json
+++ b/public/assets/i18n/app/qqq.json
@@ -24,6 +24,7 @@
   "search-placeholder": "An example filename visible in the search box. Doesn't have to exist on Commons.",
   "translate-button": "Search button text.",
   "no-translations": "Error message displayed for SVGs that have nothing to translate.",
+  "not-found": "Error message displayed if the requested file could not be found.",
 
   "pick-another": "Label for backlink from the translate page to the search page.",
   "view-on-commons": "Link to view the file on Commons. The whole phrase is linked.",

--- a/src/Controller/TranslateController.php
+++ b/src/Controller/TranslateController.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace App\Controller;
 
+use App\Exception\ImageNotFoundException;
 use App\Model\Svg\SvgFile;
 use App\Model\Title;
 use App\OOUI\TranslationsFieldset;
@@ -53,7 +54,19 @@ class TranslateController extends AbstractController
         }
 
         // Fetch the SVG from Commons.
-        $path = $cache->getPath($filename);
+        try {
+            $path = $cache->getPath($filename);
+        } catch (ImageNotFoundException $exception) {
+            $notFoundMessage = $this->renderView(
+                'error_message.html.twig',
+                ['msg_name' => 'not-found']
+            );
+            // Flash the message to show to the user under the search form.
+            $this->addFlash('search-errors', (string)$notFoundMessage);
+            // Also flash the failed filename so we can populate the search form.
+            $this->addFlash('search-redirect', $normalizedFilename);
+            return $this->redirectToRoute('home');
+        }
         $svgFile = new SvgFile($path);
 
         // If there are no strings to translate, tell the user.


### PR DESCRIPTION
Add an error message and redirect to the search form if an SVG
file can not be found.

Bug: T213272