### PR TITLE
Also check for invalid response for image info

### DIFF
--- a/src/Service/MediaWikiApi.php
+++ b/src/Service/MediaWikiApi.php
@@ -59,6 +59,7 @@ class MediaWikiApi
         if (!isset($response['query']['pages'])
             || 1 !== count($response['query']['pages'])
             || isset(reset($response['query']['pages'])['missing'])
+            || isset(reset($response['query']['pages'])['invalid'])
         ) {
             throw new ImageNotFoundException($fileName);
         }


### PR DESCRIPTION
Throw a not-found exception for filenames that are invalid. This
isn't strictly correct, but we want to handle invalid filenames
in exactly the same way as non-existing ones, so it works okay.

Bug: T213272