### PR TITLE
Throw a 404 instead of 500 when image is not found

### DIFF
--- a/src/Exception/ImageNotFoundException.php
+++ b/src/Exception/ImageNotFoundException.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace App\Exception;
 
-use Exception;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class ImageNotFoundException extends Exception
+class ImageNotFoundException extends NotFoundHttpException
 {
     public function __construct(string $fileName)
     {


### PR DESCRIPTION
500 causes emails to sent to maintainers, and here we're only dealing
with a nonexistent image, which is probably user error and not something
on our end.