### PR TITLE
Fix crashes when handling some <text>s consisting of <tspan>s

### DIFF
--- a/src/Model/Svg/SvgFile.php
+++ b/src/Model/Svg/SvgFile.php
@@ -375,7 +375,6 @@ class SvgFile
                 /** @var DOMElement $text */
                 $text = $actualNode->cloneNode(true);
                 $numChildren = $text->childNodes->length;
-                $hasActualTextContent = self::hasActualTextContent($text);
                 $lang = $text->hasAttribute('systemLanguage') ? $text->getAttribute('systemLanguage') : 'fallback';
                 $langCode = str_replace('_', '-', strtolower($lang));
 
@@ -407,13 +406,7 @@ class SvgFile
                         $counter++;
                     }
                 }
-                if ($hasActualTextContent) {
-                    // If the <text> has *its own* text content, rather than just <tspan>s, register it
-                    // for translation.
-                    $translations[$fallbackTextId][$langCode] = $this->nodeToArray($text);
-                } else {
-                    $this->filteredTextNodes[$fallbackTextId][$langCode] = $this->nodeToArray($text);
-                }
+                $this->filteredTextNodes[$fallbackTextId][$langCode] = $this->nodeToArray($text);
                 $savedLang = 'fallback' === $langCode ? $this->fallbackLanguage : $langCode;
                 $this->savedLanguages[] = $savedLang;
             }
@@ -731,40 +724,6 @@ class SvgFile
             }
         }
         return $newNode;
-    }
-
-    /**
-     * Checks whether a given DOMNode has some non-negligible text content (as
-     * opposed to just whitespace or other tags. Whitespace *between* tags
-     * counts, as it does get rendered.
-     *
-     * @param DOMNode $node The node to check for text content
-     * @return bool True if content found, false if not
-     */
-    public static function hasActualTextContent(DOMNode $node): bool
-    {
-        // No text nodes means no text content
-        if (!$node->hasChildNodes()) {
-            return false;
-        }
-
-        // Search child nodes looking for matching content
-        $children = $node->childNodes;
-        $numChildren = $children->length;
-        for ($i = 0; $i < $numChildren; $i++) {
-            if (XML_TEXT_NODE == $children->item($i)->nodeType) {
-                // Whitespace at beginning and end doesn't count, but
-                // otherwise we have a match
-                if (!0 === $i || $i === ( $numChildren - 1 )
-                    || !0 === strlen(trim($children->item($i)->textContent))
-                ) {
-                    return true;
-                }
-            }
-        }
-
-        // Didn't find any
-        return false;
     }
 
     /**

--- a/tests/Model/Svg/SvgFileTest.php
+++ b/tests/Model/Svg/SvgFileTest.php
@@ -558,4 +558,15 @@ class SvgFileTest extends TestCase
         $svg = $this->getSvg('mixed.svg');
         $this->assertCount(6, $svg->getInFileTranslations());
     }
+
+    /**
+     * https://phabricator.wikimedia.org/T220522
+     */
+    public function testChildOnly(): void
+    {
+        $svg = $this->getSvg('child-only.svg');
+        $svg->setTranslations('ru', ['trsvg1' => 'foo', 'trsvg2' => '']);
+        // Dummy assertion to avoid this test being marked as risky; the measure of success here is no crash.
+        static::assertTrue(true);
+    }
 }

--- a/tests/OOUI/TranslationsFieldsetTest.php
+++ b/tests/OOUI/TranslationsFieldsetTest.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace App\Tests\OOUI;
 
+use App\Model\Svg\SvgFile;
 use App\OOUI\TranslationsFieldset;
 use OOUI\FieldsetLayout;
 use PHPUnit\Framework\TestCase;
@@ -63,5 +64,22 @@ class TranslationsFieldsetTest extends TestCase
         /** @var FieldsetLayout[] $items */
         $items = $fieldset->getItems();
         static::assertCount(0, $items[0]->getItems());
+    }
+
+    /**
+     * Tests for undefined index warning
+     */
+    public function testChildOnlyTranslations(): void
+    {
+        $svg = new SvgFile(dirname(__DIR__).'/data/child-only.svg');
+
+        $fieldset = new TranslationsFieldset([
+            'translations' => $svg->getInFileTranslations(),
+            'source_lang_code' => 'fallback',
+            'target_lang_code' => 'ru',
+        ]);
+
+        // One group
+        static::assertCount(1, $fieldset->getItems());
     }
 }

--- a/tests/data/child-only.svg
+++ b/tests/data/child-only.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!--
+Source: reduced from https://commons.wikimedia.org/wiki/File:SVG_example_markup_grid.svg by Offnfopt and GKFX
+License: CC-0
+-->
+<svg width="391" height="391" viewBox="-70.5 -70.5 391 391" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <text>
+        <tspan x="100" y="-10">100</tspan>
+        <tspan x="200" y="-10">200</tspan>
+    </text>
+</svg>


### PR DESCRIPTION
Another warning not mentioned in the bug but present in the wild was
"Undefined index: data-parent".

The user-visible change is that it prevents pointless container messages like "$1 $2 $3"
from appearing in the interface.

Bug: T220522