### PR TITLE
Support more URLs for search input

### DIFF
--- a/src/Model/Title.php
+++ b/src/Model/Title.php
@@ -24,6 +24,13 @@ final class Title
      */
     public static function normalize(string $title): string
     {
+        $title = trim($title);
+
+        // Filenames will never have a slash, so if there is one we assume $title is a path.
+        if (false !== stripos($title, '/')) {
+            $title = basename($title);
+        }
+
         $title = self::removeNamespace($title);
         // Unicode-friendly ucfirst()
         $title = mb_strtoupper(mb_substr($title, 0, 1)).mb_substr($title, 1);

--- a/tests/Model/TitleTest.php
+++ b/tests/Model/TitleTest.php
@@ -28,13 +28,17 @@ class TitleTest extends TestCase
     {
         return [
             ['foo bar.svg', 'Foo_bar.svg'],
-            ['file:Тест.svg', 'Тест.svg'],
+            ['file:Тест.svg ', 'Тест.svg'],
             ['file:тест_123.svg', 'Тест_123.svg'],
             ['Тест.svg', 'Тест.svg'],
             ['тест_123.svg', 'Тест_123.svg'],
             [
                 'https://commons.wikimedia.org/wiki/File:Flag_of_Pakistan_Construction.svg',
                 'Flag_of_Pakistan_Construction.svg',
+            ],
+            [
+                'https://upload.wikimedia.org/wikipedia/commons/f/fa/MM_PEF.svg',
+                'MM_PEF.svg',
             ],
         ];
     }


### PR DESCRIPTION
We've been saying we support URLs as search terms, but actually
it's only been ones with "File:". This makes it more general,
and also means we can have better backwards-compatibility with
the old tool.

Bug: T224265