### PR TITLE
Add post-test build check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,3 +25,5 @@ jobs:
           command: |
             docker-compose exec web composer test
             docker-compose exec assets npm run test
+            git status
+            git status | grep "nothing to commit, working tree clean"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /.web-server-pid
 ###< symfony/web-server-bundle ###
 
+/.composer/
 /.idea/
 /node_modules/
 


### PR DESCRIPTION
Restore the check we used to have on Travis that makes sure the
asset-building hasn't changed anything in the repo.