### PR TITLE
Set trusted proxy IP addresses and host names in index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -28,6 +28,19 @@ if ($debug) {
     Debug::enable();
 }
 
+$trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false;
+if ($trustedProxies) {
+    Request::setTrustedProxies(
+        explode(',', $trustedProxies),
+        Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST
+    );
+}
+
+$trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false;
+if ($trustedHosts) {
+    Request::setTrustedHosts([$trustedHosts]);
+}
+
 $kernel = new Kernel($env, $debug);
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);


### PR DESCRIPTION
Restore Symfony's default configuration for dealing with web
proxy servers. The default env vars are already in .env.dist

https://phabricator.wikimedia.org/T223769
Bug: T223769