### PR TITLE
Removing best testing warning

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,8 +1,7 @@
 {
   "svgtranslate": "SVG Translate",
   "info": "Help translate text labels on SVG files. Pick a file on Commons to get started.",
-  "beta": "This feature is in early testing.",
-  "learn-more": "Learn more & leave feedback!",
+  "learn-more": "Learn more.",
   "return-to-home": "return to home",
 
   "help": "Help",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -9,7 +9,6 @@
 	},
 	"svgtranslate": "The title of the application.",
 	"info": "Sentences describing what this tool does and how to get started.",
-	"beta": "Message informing the user that the application is currently of beta quality.",
 	"learn-more": "Text for a link to the on-wiki project page for the tool (the same destination as the link of {{msg-mw|help}}).",
 	"return-to-home": "Link to homepage that's displayed on error message pages.",
 	"help": "Text for a 'help' link to the tool's project page on Meta (the same destination as the link of {{msg-mw|learn-more}}). Displayed in the footer on every page.",

--- a/public/assets/i18n/app/en.json
+++ b/public/assets/i18n/app/en.json
@@ -1,8 +1,7 @@
 {
   "svgtranslate": "SVG Translate",
   "info": "Help translate text labels on SVG files. Pick a file on Commons to get started.",
-  "beta": "This feature is in early testing.",
-  "learn-more": "Learn more & leave feedback!",
+  "learn-more": "Learn more.",
   "return-to-home": "return to home",
 
   "help": "Help",

--- a/public/assets/i18n/app/qqq.json
+++ b/public/assets/i18n/app/qqq.json
@@ -9,7 +9,6 @@
 	},
 	"svgtranslate": "The title of the application.",
 	"info": "Sentences describing what this tool does and how to get started.",
-	"beta": "Message informing the user that the application is currently of beta quality.",
 	"learn-more": "Text for a link to the on-wiki project page for the tool (the same destination as the link of {{msg-mw|help}}).",
 	"return-to-home": "Link to homepage that's displayed on error message pages.",
 	"help": "Text for a 'help' link to the tool's project page on Meta (the same destination as the link of {{msg-mw|learn-more}}). Displayed in the footer on every page.",

--- a/templates/search.html.twig
+++ b/templates/search.html.twig
@@ -5,9 +5,8 @@
 {% endblock %}
 
 {% block description %}
-    <p>{{ msg('info') }}</p>
     <p>
-        {{ msg('beta') }}
+        {{ msg('info') }}
         <a href="https://commons.wikimedia.org/wiki/Special:MyLanguage/Commons:SVG_Translate_tool">{{ msg('learn-more') }}</a>
     </p>
 {% endblock %}


### PR DESCRIPTION
Tool is no longer in testing phase.