### PR TITLE
Allow tspan to be in svg namespace

### DIFF
--- a/src/Model/Svg/SvgFile.php
+++ b/src/Model/Svg/SvgFile.php
@@ -214,7 +214,7 @@ class SvgFile
             // Everything in a <text> should be a <tspan>s, otherwise we can't translate it
             for ($i = 0; $i < count($text->childNodes); $i++) {
                 $node = $text->childNodes[$i];
-                if ('tspan' === $node->nodeName) {
+                if ('tspan' === $node->nodeName || 'svg:tspan' === $node->nodeName) {
                     continue;
                 }
                 if (XML_TEXT_NODE !== $node->nodeType) {


### PR DESCRIPTION
If a tspan had an `svg:` namespace, it was seen as an "unexpected
tag in translatable content". This adds tests to isolate this bug
(also checking that switch, text elements can be in the svg
namespace, which they can).

Logging is added to the SvgFileTest, for easier debugging.

Bug: T271000