### PR TITLE
Create ButtonWidget with manual input, to avoid wrong type

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -24,7 +24,7 @@ return [
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/Controller/SearchController.php' => ['PhanAccessMethodInternal', 'PhanTypeMismatchArgumentProbablyReal'],
+        'src/Controller/SearchController.php' => ['PhanAccessMethodInternal'],
         'src/Controller/TranslateController.php' => ['PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypePossiblyInvalidDimOffset'],
         'src/Model/Svg/SvgFile.php' => ['PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod'],
         'src/OOUI/TranslationsFieldset.php' => ['PhanCommentDuplicateParam', 'PhanTypeSuspiciousNonTraversableForeach'],

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -7,9 +7,10 @@ use App\Model\Title;
 use App\OOUI\SearchWidget;
 use Krinkle\Intuition\Intuition;
 use OOUI\ActionFieldLayout;
-use OOUI\ButtonInputWidget;
+use OOUI\ButtonWidget;
 use OOUI\FormLayout;
 use OOUI\HtmlSnippet;
+use OOUI\Tag;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -32,8 +33,10 @@ class SearchController extends AbstractController
             'infusable' => true,
             'value' => $failedSearchTerm[0] ?? '',
         ]);
-        $submitButton = new ButtonInputWidget([
-            'type' => 'submit',
+        $button = new Tag( 'button' );
+        $button->setAttributes(['type' => 'submit']);
+        $submitButton = new ButtonWidget([
+            'button' => $button,
             'label' => $intuition->msg('translate-button'),
             'flags' =>  ['primary', 'progressive'],
         ]);


### PR DESCRIPTION
ActionFieldLayout only accepts a ButtonWidget and not a
ButtonInputWidget, so this switches the main 'translate' button
to manually create it as a ButtonWidget with a <button type="submit">
element.

Bug: T316310