### PR TITLE
Tidy up switch text checks

### DIFF
--- a/.phan/baseline.php
+++ b/.phan/baseline.php
@@ -26,7 +26,7 @@ return [
     'file_suppressions' => [
         'src/Controller/SearchController.php' => ['PhanAccessMethodInternal', 'PhanTypeMismatchArgumentProbablyReal'],
         'src/Controller/TranslateController.php' => ['PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchDeclaredParamNullable', 'PhanTypePossiblyInvalidDimOffset'],
-        'src/Model/Svg/SvgFile.php' => ['PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullable', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod'],
+        'src/Model/Svg/SvgFile.php' => ['PhanTypeMismatchArgumentInternalProbablyReal', 'PhanTypeMismatchArgumentNullableInternal', 'PhanTypeMismatchPropertyProbablyReal', 'PhanUndeclaredMethod'],
         'src/OOUI/TranslationsFieldset.php' => ['PhanCommentDuplicateParam', 'PhanTypeSuspiciousNonTraversableForeach'],
         'src/Service/MediaWikiApi.php' => ['PhanDeprecatedFunction'],
         'src/Service/Renderer.php' => ['PhanTypeMismatchDeclaredParamNullable'],

--- a/src/Controller/TranslateController.php
+++ b/src/Controller/TranslateController.php
@@ -78,7 +78,7 @@ class TranslateController extends AbstractController
         } catch (RequestException $exception) {
             return $this->showError('network-error', $normalizedFilename);
         } catch (NestedTspanException $exception) {
-            $id = $exception->getTspanId();
+            $id = $exception->getClosestId();
             $reason = $id
                 ? $intuition->msg('nested-tspans-with-id', [ 'variables' => [ "<code>#$id</code>" ] ] )
                 : $intuition->msg( 'nested-tspans-without-id' );

--- a/src/Exception/NestedTspanException.php
+++ b/src/Exception/NestedTspanException.php
@@ -4,40 +4,12 @@ declare(strict_types = 1);
 namespace App\Exception;
 
 use DOMElement;
-use Exception;
 
-class NestedTspanException extends Exception
+class NestedTspanException extends SvgStructureException
 {
-
-    /** @var DOMElement */
-    protected $tspan;
 
     public function __construct(DOMElement $tspan)
     {
-        $this->tspan = $tspan;
-        $msg = 'Nested tspan elements are not supported '
-            .'(ID: "'.$this->getTspanId().'"; text: "'.$this->getTextContent().'")';
-        parent::__construct($msg);
-    }
-
-    /**
-     * Get the closest ID to the nested tspan.
-     * @return string
-     */
-    public function getTspanId(): string
-    {
-        $el = $this->tspan;
-        $id = '';
-        // Traverse up the tree to find an ID.
-        while (!$id && 'svg' !== $el->nodeName) {
-            $id = $el->getAttribute('id');
-            $el = $el->parentNode;
-        }
-        return $id;
-    }
-
-    public function getTextContent(): string
-    {
-        return $this->tspan->textContent;
+        parent::__construct('Nested tspan elements are not supported', $tspan);
     }
 }

--- a/src/Exception/SvgStructureException.php
+++ b/src/Exception/SvgStructureException.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types = 1);
+
+namespace App\Exception;
+
+use DOMNode;
+use Exception;
+
+class SvgStructureException extends Exception
+{
+
+    /** @var DOMNode */
+    private $node;
+
+    public function __construct(string $message, DOMNode $node)
+    {
+        $this->node = $node;
+        $msg = $message
+            .' (ID: "'.$this->getClosestId().'"; text: "'.$this->getTextContent().'")';
+        parent::__construct($msg);
+    }
+
+    /**
+     * Get the closest ID to the given element.
+     * @return string
+     */
+    public function getClosestId(): string
+    {
+        $node = $this->node;
+        $id = '';
+        // Traverse up the tree to find an ID.
+        while (!$id && 'svg' !== $node->nodeName) {
+            $id = $node->attributes->getNamedItem('id')->textContent ?? '';
+            $node = $node->parentNode;
+        }
+        return $id;
+    }
+
+    /**
+     * Get a simplified representation of the text content of the element.
+     * @return string
+     */
+    public function getTextContent(): string {
+        return $this->node->textContent;
+    }
+}


### PR DESCRIPTION
Add a new SvgStructureException so we've got a more general-use
exception for this sort of issue. Then use this new exception
when finding multiple <text> elements in a <switch> where they
have the same systemLanguage attribute.

Change the existing NestedTspanException to use the new one.

Bug: T316310