### PR TITLE
Make main search field required

### DIFF
--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -32,6 +32,7 @@ class SearchController extends AbstractController
             'id' => 'search-widget',
             'infusable' => true,
             'value' => $failedSearchTerm[0] ?? '',
+            'required' => true,
         ]);
         $button = new Tag( 'button' );
         $button->setAttributes(['type' => 'submit']);


### PR DESCRIPTION
Otherwise, clicking Translate just ends up back at the form with no indication why nothing happened.