### PR TITLE
Fix typo in message name

### DIFF
--- a/src/Model/Svg/SvgFile.php
+++ b/src/Model/Svg/SvgFile.php
@@ -202,7 +202,7 @@ class SvgFile
                 || ( 1 == $tspan->childNodes->length && XML_TEXT_NODE !== $tspan->childNodes->item(0)->nodeType )
             ) {
                 // Nested tspans not (yet) supported. T250607.
-                throw new SvgStructureException('structure-error-nested-tspan-not-supported', $tspan);
+                throw new SvgStructureException('structure-error-nested-tspans-not-supported', $tspan);
             }
             $translatableNodes[] = $tspan;
         }

--- a/tests/Model/Svg/SvgFileTest.php
+++ b/tests/Model/Svg/SvgFileTest.php
@@ -698,17 +698,17 @@ class SvgFileTest extends TestCase
         return [
             'Simple nested tspan' => [
                 'svg' => '<svg><text><tspan>foo <tspan>bar</tspan></tspan></text></svg>',
-                'message' => 'structure-error-nested-tspan-not-supported',
+                'message' => 'structure-error-nested-tspans-not-supported',
                 'params' => [0 => ''],
             ],
             'Nested tspan with ID' => [
                 'svg' => '<svg><text><tspan id="test">foo <tspan>bar</tspan></tspan></text></svg>',
-                'message' => 'structure-error-nested-tspan-not-supported',
+                'message' => 'structure-error-nested-tspans-not-supported',
                 'params' => [0 => 'test'],
             ],
             'Nested tspan with grandparent with ID' => [
                 'svg' => '<svg><g id="gparent"><text><tspan>foo <tspan>bar</tspan></tspan></text></g></svg>',
-                'message' => 'structure-error-nested-tspan-not-supported',
+                'message' => 'structure-error-nested-tspans-not-supported',
                 'params' => [0 => 'gparent'],
             ],
             'CSS too complex' => [


### PR DESCRIPTION
Message 'structure-error-nested-tspans-not-supported' had a typo.