### PR TITLE
Fail earlier for multiple-text-same-lang structure

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -30,7 +30,7 @@
 
   "structure-error-no-doc-element": "No document element found.",
   "structure-error-nested-tspans-not-supported": "This file can not be translated because it contains nested tspan elements in $1.",
-  "structure-error-multiple-text-same-lang": "Multiple text elements found with language '$1'",
+  "structure-error-multiple-text-same-lang": "Multiple text elements found with language code '$2' (in element with ID '$1').",
   "structure-error-contains-tref": "This file contains tref tags, which are not supported by this tool.",
   "structure-error-css-too-complex": "This file contains CSS that is too complicated to parse.",
   "structure-error-css-has-ids": "This file uses element IDs in the CSS, which may break when SVG Translate adds new IDs. It should use classes instead, if possible.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -43,7 +43,7 @@
 	"structure-error-css-has-ids": "Message displayed when an SVG file has an error that renders it untranslatable.",
 	"structure-error-unexpected-node-in-text": "Message displayed when an SVG file has an error that renders it untranslatable.",
 	"structure-error-invalid-node-id": "Message displayed when an SVG file has an error that renders it untranslatable.\n\nParameters:\n* $1 — Closest parent element ID.",
-	"structure-error-text-contains-dollar": "Message displayed when an SVG file has an error that renders it untranslatable.\n\nParameters:\n* $1 — Closest parent element ID.",
+	"structure-error-text-contains-dollar": "Message displayed when an SVG file has an error that renders it untranslatable.\n\nParameters:\n* $1 — Closest parent element ID.\n* $2 — Offending text content.",
 	"structure-error-non-tspan-inside-text": "Message displayed when an SVG file has an error that renders it untranslatable.",
 	"structure-error-switch-text-is-not-node": "Message displayed when an SVG file has an error that renders it untranslatable.",
 	"structure-error-switch-text-content-outside-text": "Message displayed when an SVG file has an error that renders it untranslatable.",

--- a/src/Controller/TranslateController.php
+++ b/src/Controller/TranslateController.php
@@ -80,9 +80,10 @@ class TranslateController extends AbstractController
             return $this->showError('network-error', $normalizedFilename);
         } catch (SvgStructureException $exception) {
             $msgParams = $exception->getMessageParams();
-            // Get the element ID, or fall back to the no-ID placeholder message.
-            $id = $exception->getClosestId();
-            array_unshift($msgParams, $id ?: $intuition->msg('structure-error-no-id'));
+            // If there's no element ID fall back to the no-ID placeholder message.
+            if ($msgParams[0] === null) {
+                $msgParams[0] = $intuition->msg('structure-error-no-id');
+            }
             return $this->showError(
                 $exception->getMessage(),
                 $normalizedFilename,

--- a/tests/Model/Svg/SvgFileTest.php
+++ b/tests/Model/Svg/SvgFileTest.php
@@ -774,7 +774,7 @@ class SvgFileTest extends TestCase
                 . '</svg>');
                 $svgFile3->setTranslations('la', ['trsvg3' => 'lang la (new)']);
         } catch (SvgStructureException $exception) {
-            $this->assertSame('multiple-text-same-lang', $exception->getMessage());
+            $this->assertSame('structure-error-multiple-text-same-lang', $exception->getMessage());
             $this->assertSame(['testswitch', 'la'], $exception->getMessageParams());
         }
     }


### PR DESCRIPTION
It's not permitted to have multiple `<text>` elements with the same language code in a `<switch>` element. This wasn't being checked in `SvgFile::makeTranslationRead()`, but only later in `SvgFile::switchToTranslationSet()`, and so it wasn't being reported to the user when they opened a file for translation, but only later when they tried to load a translated version (at which point it failed without telling them why).

This change moves the multiple-language check to the earlier method, and fixes up some broken parts of 91d30977e1180e983b3720c3aa486f8d88dae29d such as the error message name and parameters, as well as i18n messages and documentation.

This doesn't remove the later check, even though it's now redundant. That can be done in a follow-up.

Bug: T319154