### PR TITLE
Add linting to composer test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,8 +103,13 @@
             "@php ./bin/phpunit tests"
         ],
         "test": [
+            "@lint",
             "@phpunit",
             "@phan"
+        ],
+        "fix": [
+            "minus-x fix .",
+            "phpcbf"
         ]
     },
     "conflict": {


### PR DESCRIPTION
The Wikimedia convention is for `composer test` to run all linting and tests etc. but SVG Translate has had separate test and lint scripts. This is probably part of why the linting has been forgotten in recent times.

Also add a new `composer fix` script, in keeping with convention.

Bug: T318066