### PR TITLE
Use rsvg-convert --accept-language rather than LANG env var

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
 			"@generate-test-data"
 		],
 		"generate-test-data": [
-			"LANG=de rsvg-convert ./tests/data/Speech_bubbles.svg > ./tests/data/Speech_bubbles.png"
+			"rsvg-convert --accept-language=de ./tests/data/Speech_bubbles.svg > ./tests/data/Speech_bubbles.png"
 		],
 		"lint": [
 			"composer validate",

--- a/src/Service/Renderer.php
+++ b/src/Service/Renderer.php
@@ -36,17 +36,17 @@ class Renderer
     {
         // Construct the command, using variables that will be escaped when it's run.
         $command = $this->rsvgCommand.' "$SVG"';
+        if ('fallback' !== $lang) {
+            // Set the language to use from the SVG systemLanguage.
+            // If the fallback language is being requested, the OS's default will be
+            // used instead (as is done in MediaWiki).
+            $command .= " --accept-language=$lang";
+        }
         if ($outFile) {
             // Redirect to output file if required.
             $command .= ' > "$PNG"';
         }
         $process = Process::fromShellCommandline($command);
-        if ('fallback' !== $lang) {
-            // Set the LANG environment variable, which will be interpreted as the SVG
-            // systemLanguage. If the fallback language is being requested, the OS's default will be
-            // used instead (as is done in MediaWiki).
-            $process->setEnv(['LANG' => $lang]);
-        }
         $process->mustRun(null, ['SVG' => $file, 'PNG' => $outFile]);
         return $process->getOutput();
     }


### PR DESCRIPTION
Set the language used by rsvg-convert via the --accept-language CLI option rather than the LANG environment variable, as there seems to be an issue with the order of which env var gets used. More info:
https://github.com/GNOME/librsvg/blob/main/rsvg-convert.rst#environment-variables

Also update the built assets, so CI passes.

Bug: T358305