### PR TITLE
Change the Commons test file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build
       run: |
-          npm run build
+        npm run build
 
     - name: Test
       run: |

--- a/tests/Controller/TranslateControllerTest.php
+++ b/tests/Controller/TranslateControllerTest.php
@@ -15,10 +15,10 @@ class TranslateControllerTest extends WebTestCase
     public function testExists(): void
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '/File:Test.svg');
+        $crawler = $client->request('GET', '/File:SVG_Translate_test_-_valid.svg');
         $response = $client->getResponse();
         static::assertEquals(200, $response->getStatusCode());
-        static::assertStringContainsString('Test.svg', $crawler->filter('h1')->text());
+        static::assertStringContainsString('SVG Translate test - valid.svg', $crawler->filter('h1')->text());
     }
 
     public function testNonSvgHandling(): void


### PR DESCRIPTION
The Test.svg file gets changed by people sometimes, causing the svgtranslate CI tests to fail, so to avoid issues this switches to a file that's specifically labelled as being used for this purpose.

Also fix an indent in ci.yml.