### PR TITLE
Fix JSON storage in svgtranslate cookie

### DIFF
--- a/assets/LanguageDialog.js
+++ b/assets/LanguageDialog.js
@@ -119,18 +119,12 @@ App.LanguageDialog.prototype.getActionProcess = function ( action ) {
 	var dialog = this;
 	if ( action === 'done' ) {
 		return new OO.ui.Process( function () {
-			var newUrl,
-				cookieVal = {
-					interfaceLang: dialog.interfaceLangButton.currentLang,
-					preferredLangs: dialog.preferredLangsWidget.getValue()
-				},
-				Cookies = require( 'js-cookie' );
 			// Store the new cookie value.
-			// This is the only place the SVG Translate cookie is written.
-			Cookies.set( 'svgtranslate', cookieVal );
+			App.setCookieVal( 'interfaceLang', dialog.interfaceLangButton.currentLang );
+			App.setCookieVal( 'preferredLangs', dialog.preferredLangsWidget.getValue() );
 			// Redirect back to where we currently are (without the #lang-settings fragment),
 			// in order to reload the interface in the new language.
-			newUrl = window.location.href.slice( 0, window.location.href.indexOf( '#' ) );
+			var newUrl = window.location.href.slice( 0, window.location.href.indexOf( '#' ) );
 			window.location.href = newUrl;
 			dialog.close( { action: action } );
 		} );

--- a/assets/app.js
+++ b/assets/app.js
@@ -39,8 +39,8 @@ $( function () {
  */
 App.getCookieVal = function ( key, defaultVal ) {
 	var cookieData,
-		Cookies = require( 'js-cookie' ),
-		cookie = Cookies.get( 'svgtranslate' );
+		JsCookie = require( 'js-cookie' ),
+		cookie = JsCookie.get( 'svgtranslate' );
 	if ( cookie ) {
 		try {
 			cookieData = JSON.parse( cookie );
@@ -52,6 +52,27 @@ App.getCookieVal = function ( key, defaultVal ) {
 	}
 	// If no cookie is set, return the default.
 	return defaultVal;
+};
+
+/**
+ * Set a value in the svgtranslate cookie.
+ *
+ * @param {string} key
+ * @param {*} val
+ */
+App.setCookieVal = function ( key, val ) {
+	var JsCookie = require( 'js-cookie' );
+	var cookie = {};
+	var cookieData = JsCookie.get( 'svgtranslate' );
+	if ( cookieData ) {
+		try {
+			cookie = JSON.parse( cookieData );
+		} catch ( e ) {
+			// If the cookie is invalid JSON, ignore it.
+		}
+	}
+	cookie[ key ] = val;
+	JsCookie.set( 'svgtranslate', JSON.stringify( cookie ) );
 };
 
 /**


### PR DESCRIPTION
JSON-encode the svgtranslate cookie when setting it.

Also move the setting of the svgtranslate cookie into app.js, where the cookie is already being read.

Bug: T401483